### PR TITLE
Feat/tweet count over 200

### DIFF
--- a/src/botCommands.js
+++ b/src/botCommands.js
@@ -135,6 +135,7 @@ export const tweet = async ({ count, flags, ...params }) => {
       ...params,
       count: TWEETS_MAX,
     };
+    const noRetweet = flags.indexOf('noretweet') !== -1;
     while (tweets.length < count && !doneWithTimeline) {
       // We can't really avoid await-ing inside of a loop here
       // as we don't know how often we need to await until we've read the result.
@@ -150,7 +151,7 @@ export const tweet = async ({ count, flags, ...params }) => {
       }
       // Filter out retweets if the user asked us to
       tweets.push(
-        ...(flags.noretweet
+        ...(noRetweet
           ? res.filter(({
             retweeted_status: retweetedStatus,
           }) => !retweetedStatus)

--- a/src/botCommands.js
+++ b/src/botCommands.js
@@ -1,6 +1,6 @@
 import log from './log';
 import {
-  userTimeline, userLookup, createStream, getError, showTweet, formatTweet,
+  userTimeline, userLookup, createStream, getError, showTweet, formatTweet, hasMedia,
 } from './twitter';
 import {
   rm, add, getUserIds as getAllSubs, getUniqueChannels,
@@ -136,6 +136,7 @@ export const tweet = async ({ count, flags, ...params }) => {
       count: TWEETS_MAX,
     };
     const noRetweet = flags.indexOf('noretweet') !== -1;
+    const noText = flags.indexOf('notext') !== -1;
     while (tweets.length < count && !doneWithTimeline) {
       // We can't really avoid await-ing inside of a loop here
       // as we don't know how often we need to await until we've read the result.
@@ -151,11 +152,10 @@ export const tweet = async ({ count, flags, ...params }) => {
       }
       // Filter out retweets if the user asked us to
       tweets.push(
-        ...(noRetweet
-          ? res.filter(({
-            retweeted_status: retweetedStatus,
-          }) => !retweetedStatus)
-          : res),
+        ...res.filter((t) => (
+          (!noText || hasMedia(t))
+          && (!noRetweet || !t.retweeted_status)
+        )),
       );
     }
     return tweets.slice(0, count);

--- a/src/shard/commands.js
+++ b/src/shard/commands.js
@@ -104,12 +104,13 @@ export const handleUserTimeline = async ({
   }
   const formattedTweets = await Promise.all(validTweets.map((t) => formatTweet(t, false)));
   const embeds = formattedTweets.map(({ embed }) => embed);
+  const reverseOrder = flags.indexOf('reverse') !== -1;
   const {
     successful,
     err,
     // So I know this is weird but we originally got tweets in the WRONG order, from most recent to oldest
     // If we get the reverse flag, we therefore DON'T reverse, we just leave it in the wrong order
-  } = await postEmbeds(qChannel, flags.reverse ? embeds : embeds.reverse());
+  } = await postEmbeds(qChannel, reverseOrder ? embeds : embeds.reverse());
   if (err) {
     log(`Error posting tweet ${successful + 1} / ${validTweets.length} from ${screenName}`, qChannel);
     log(err);

--- a/src/twitter.js
+++ b/src/twitter.js
@@ -55,7 +55,7 @@ function resetTwitterTimeout() {
 }
 
 // Checks if a tweet has any media attached. If false, it's a text tweet
-const hasMedia = ({
+export const hasMedia = ({
   extended_entities: extendedEntities,
   extended_tweet: extendedTweet,
   retweeted_status: retweetedStatus,


### PR DESCRIPTION
This PR does a few things:

- Make it so people can request more than 200 tweets at a time with `!!tweet`.
- Give users the ability to filter the tweets they're getting a bit with `--noretweet` and `--notext`.
- Provide a `--reverse` flags so tweets are posted from newest to oldest and not the other way around.