### PR TITLE
Stream destroy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         PREFIX: "${PREFIX}"
         BOT_NAME: "${BOT_NAME}"
     image: navenn_t/qtweet
-    restart: on-failure
+    restart: always
     environment:
       TZ: ${TIMEZONE}
       PGHOST: postgres

--- a/src/twitterStream.js
+++ b/src/twitterStream.js
@@ -26,7 +26,7 @@ class Stream {
       log('⚙️ New users found!', null, true);
       this.newUserIds = false;
       if (this.stream) {
-        this.stream.destroy();
+        process.exit();
         this.stream = null;
         log(`⚙️ Destroying stream for re-creation in ${destroyDelay}ms`, null, true);
         setTimeout(() => {
@@ -79,7 +79,7 @@ class Stream {
     if (this.stream) {
       log('Destroying stream');
       try {
-        this.stream.destroy();
+        process.exit();
       } catch (e) {
         console.error('Tried to destroy a stream but ran into error:');
         console.error(e);


### PR DESCRIPTION
I have changed a few lines to cause the stream to shut itself down since I get stuck in a exit loop on errors with current code. More of a hack than an upgrade, but have been using it for about 4 months and has been working great. Only downtime has been affiliated with ISP or server errors. Bot is running amazing. 